### PR TITLE
MNT: Add range of supported CMakes patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Summary: QCDLoop: an object-oriented one-loop scalar Feynman integrals framework
 
 Development: https://github.com/scarrazza/qcdloop
 
+Documentation: https://qcdloop.web.cern.ch/
+
 Current build status
 ====================
 

--- a/recipe/0003-support-range-of-cmakes.patch
+++ b/recipe/0003-support-range-of-cmakes.patch
@@ -1,0 +1,24 @@
+From b3e25a1b12471e1760dbfa8ae1fff73f8d5d8d44 Mon Sep 17 00:00:00 2001
+From: Matthew Feickert <matthew.feickert@cern.ch>
+Date: Fri, 15 Nov 2024 00:16:01 -0700
+Subject: [PATCH] MNT: Provide range of CMakes to cmake_minimum_required
+
+* Set lower bound of 3.12, when the range feature was introduced, and
+  upper bound of 3.31, the current latest release.
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 412b98c..fa7780b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required (VERSION 3.0.2)
++cmake_minimum_required(VERSION 3.12...3.31)
+ 
+ # Disable the use of RPATHS - we probably are not
+ # that interested in relocatable binaries and it
+-- 
+2.47.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,13 @@ source:
     - 0001-fix-Use-grep-E-over-egrep.patch
     # Allow setting CMAKE_CXX_FLAGS from CXXFLAGS
     - 0002-environment-override-of-CMAKE_CXX_FLAGS.patch
+    # Give cmake_minimum_required a range of supported CMakes
+    - 0003-support-range-of-cmakes.patch
 
 build:
   # FIXME: clang does not yet support quadmath, so macOS builds are broken
   skip: true  # [not linux]
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage('qcdloop', max_pin='x.x') }}
   script:
@@ -84,6 +86,7 @@ about:
   license: GPL-3.0-only
   license_family: GPL
   license_file: source/LICENSE
+  doc_url: https://qcdloop.web.cern.ch/
   dev_url: https://github.com/scarrazza/qcdloop
 
 extra:


### PR DESCRIPTION
* Allow modern CMake to be used.
* Add docs url: https://qcdloop.web.cern.ch/
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
